### PR TITLE
Feature/cloud function get apk download url

### DIFF
--- a/firebase-functions/README.md
+++ b/firebase-functions/README.md
@@ -2,15 +2,20 @@
 
 This folder contains the firebase cloud functions for the trustlines.network site.
 
+## Firebase service account
+
+As we are using Firebase Storage to store the production release of the app, we need a firebase cloud function to retrieve the download url. This function can be found in `src/apk/get-download-url.ts`. For this we also need a service account that has access to the bucket of the `Trustlines Production` firebase project. Therefore copy the respective service account credentials JSON from 1Password and put it in `src/apk/trustlines-production-service-account.json`.
+
 ## Environment variables
+
 The functions rely on some env variables to work. An example `env.dist.json`
 file is distributed in the functions folder. Change the file name to either
 `env.dev.json` or `env.prod.json` depending on what kind of config you are providing.
 
 The emails.contactUs variable accepts multiple emails separated by comma.
 
-
 If you are testing the functions locally run:
+
 ```
 yarn config:set:dev
 ```

--- a/firebase-functions/functions/.gitignore
+++ b/firebase-functions/functions/.gitignore
@@ -10,3 +10,5 @@ typings/
 
 # Node.js dependency directory
 node_modules/
+
+trustlines-production-service-account.json

--- a/firebase-functions/functions/src/apk/get-download-url.ts
+++ b/firebase-functions/functions/src/apk/get-download-url.ts
@@ -5,6 +5,9 @@ import * as admin from "firebase-admin";
 
 import serviceAccount from "./trustlines-production-service-account.json";
 
+const BUCKET_NAME = "trustlines-38c29.appspot.com";
+const FILE_NAME = "app-production-release.apk";
+
 const app = admin.initializeApp({
   credential: admin.credential.cert(serviceAccount as any),
 });
@@ -28,8 +31,8 @@ export const apkGetDownloadUrl = functions
     }
 
     const storage = admin.storage(app);
-    const bucket = storage.bucket("trustlines-38c29.appspot.com");
-    const file = bucket.file("app-production-release.apk");
+    const bucket = storage.bucket(BUCKET_NAME);
+    const file = bucket.file(FILE_NAME);
 
     file
       .getSignedUrl({

--- a/firebase-functions/functions/src/apk/get-download-url.ts
+++ b/firebase-functions/functions/src/apk/get-download-url.ts
@@ -5,6 +5,10 @@ import * as admin from "firebase-admin";
 
 import serviceAccount from "./trustlines-production-service-account.json";
 
+const app = admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount as any),
+});
+
 export const apkGetDownloadUrl = functions
   .region(region)
   .https.onRequest((req: any, res: any) => {
@@ -23,9 +27,6 @@ export const apkGetDownloadUrl = functions
       res.status(403).send("Forbidden!");
     }
 
-    const app = admin.initializeApp({
-      credential: admin.credential.cert(serviceAccount as any),
-    });
     const storage = admin.storage(app);
     const bucket = storage.bucket("trustlines-38c29.appspot.com");
     const file = bucket.file("app-production-release.apk");

--- a/firebase-functions/functions/src/apk/get-download-url.ts
+++ b/firebase-functions/functions/src/apk/get-download-url.ts
@@ -1,0 +1,40 @@
+import { region } from "../constants";
+
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+import serviceAccount from "./trustlines-production-service-account.json";
+
+export const apkGetDownloadUrl = functions
+  .region(region)
+  .https.onRequest((req: any, res: any) => {
+    res.set("Access-Control-Allow-Origin", "*");
+
+    // Deal with cors requests
+    if (req.method === "OPTIONS") {
+      // Send response to OPTIONS requests
+      res.set("Access-Control-Allow-Methods", "POST");
+      res.set("Access-Control-Allow-Headers", "Content-Type");
+      res.set("Access-Control-Max-Age", "3600");
+      return res.status(204).send("");
+    }
+
+    if (req.method !== "GET") {
+      res.status(403).send("Forbidden!");
+    }
+
+    const app = admin.initializeApp({
+      credential: admin.credential.cert(serviceAccount as any),
+    });
+    const storage = admin.storage(app);
+    const bucket = storage.bucket("trustlines-38c29.appspot.com");
+    const file = bucket.file("app-production-release.apk");
+
+    file
+      .getSignedUrl({
+        action: "read",
+        expires: "03-09-2491",
+      })
+      .then((urls) => res.status(200).json(urls[0]))
+      .catch((error) => res.status(500).json({ message: error.message }));
+  });

--- a/firebase-functions/functions/src/index.ts
+++ b/firebase-functions/functions/src/index.ts
@@ -1,1 +1,2 @@
 export { websiteContact } from "./website/contact";
+export { apkGetDownloadUrl } from "./apk/get-download-url";

--- a/firebase-functions/functions/tsconfig.json
+++ b/firebase-functions/functions/tsconfig.json
@@ -8,10 +8,10 @@
     "strict": true,
     "target": "es2017",
     "moduleResolution": "node",
-    "types": []
+    "types": [],
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
   "compileOnSave": true,
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Adds cloud function to retrieve apk download link for firebase storage. I could not deploy the functions because I don't have permission @compojoom. Locally it worked though. And AFAICT the download link should stay the same because I set the expiration date to a very far away date.

UPDATE: Just tested with different files and the link stays the same. So theoretically we do not need to deploy the functions.

Related: 
- https://github.com/trustlines-network/mobileapp/pull/1514
- https://github.com/brainbot-com/www.trustlines.app/pull/40